### PR TITLE
Remove all favorites

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -24,4 +24,10 @@ class FavoritesController <  ApplicationController
     flash[:notice] = "You have removed #{pet.name} from favorites"
     redirect_to "/favorites"
   end
+
+  def remove_all
+    favorites.remove_all
+    flash[:notice] = "You have removed all pets from favorites"
+    redirect_to "/favorites"
+  end
 end

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -12,11 +12,15 @@ class Favorite
   def add_pet(pet)
     @pet_data << pet.id
   end
-  
+
   def remove_pet(pet)
     @pet_data.delete(pet)
   end
-  
+
+  def remove_all
+    @pet_data.clear
+  end
+
   def find_pets
     @pet_data.map do |id|
       Pet.find(id)

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -45,4 +45,5 @@
     <% end %>
 </div>
 </section>
+<%= link_to "remove all favorited pets", "/favorites", method: :delete %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,4 +37,6 @@ Rails.application.routes.draw do
   delete "/pets/:pet_id/favorite", to: 'favorites#destroy'
 
   delete "/favorites/:pet_id", to: 'favorites#remove'
+
+  delete "/favorites", to: 'favorites#remove_all'
 end

--- a/spec/features/favorites/user_can_remove_a_favorite_from_favorites_page_spec.rb
+++ b/spec/features/favorites/user_can_remove_a_favorite_from_favorites_page_spec.rb
@@ -32,4 +32,19 @@ RSpec.describe 'favorite removal', type: :feature do
     expect(page).to_not have_link("#{@pet_1.name}")
     expect(current_path).to eq("/favorites")
   end
+
+  it 'can remove all favorites' do
+    visit "/favorites"
+
+    expect(page).to have_link("#{@pet_2.name}")
+    expect(page).to have_link("#{@pet_3.name}")
+
+    click_link "remove all favorited pets"
+
+    expect(current_path).to eq("/favorites")
+    expect(page).to have_content("no favorited pets")
+    expect(page).to have_content("favorites: 0")
+    expect(page).to_not have_link("#{@pet_2.name}")
+    expect(page).to_not have_link("#{@pet_3.name}")
+  end
 end

--- a/spec/features/favorites/user_can_remove_all_favorites_spec.rb
+++ b/spec/features/favorites/user_can_remove_all_favorites_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe 'favorite removal', type: :feature do
       click_on "add to favorites"
   end
 
-  it 'can remove a pet from favorites' do
+  it 'can remove all favorites' do
     visit "/favorites"
 
-    expect(page).to have_content("favorites: 3")
-    expect(page).to have_link("#{@pet_1.name}")
+    expect(page).to have_link("#{@pet_2.name}")
+    expect(page).to have_link("#{@pet_3.name}")
 
-    within("#pet-#{@pet_1.id}") do
-      click_link "remove from favorites"
-    end
+    click_link "remove all favorited pets"
 
-    expect(page).to have_content("You have removed #{@pet_1.name} from favorites")
-    expect(page).to_not have_link("#{@pet_1.name}")
     expect(current_path).to eq("/favorites")
+    expect(page).to have_content("no favorited pets")
+    expect(page).to have_content("favorites: 0")
+    expect(page).to_not have_link("#{@pet_2.name}")
+    expect(page).to_not have_link("#{@pet_3.name}")
   end
 end

--- a/spec/models/favorite_spec.rb
+++ b/spec/models/favorite_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Favorite do
     @pet_1 = create(:pet, name: "persy", age: 8, sex: "male", shelter: @shelter_1)
     @pet_2 = create(:pet, name: "piper", age: 12, sex: "female", shelter: @shelter_2)
     @pet_3 = create(:pet, name: "holie", age: 4, sex: "female", shelter: @shelter_2)
+    @pet_3 = create(:pet, name: "harry", age: 5, sex: "male", shelter: @shelter_2)
   end
 
   it 'has can count pets' do
@@ -38,5 +39,10 @@ RSpec.describe Favorite do
   it 'can find all pets' do
     @favorite.add_pet(@pet_3)
     expect(@favorite.find_pets).to eq([@pet_1, @pet_2, @pet_3])
+  end
+
+  it 'can remove all' do
+    @favorite.remove_all
+    expect(@favorite.find_pets).to eq([])
   end
 end


### PR DESCRIPTION
User sees a link on the favorites index page to remove all the favorited pets. When clicked it redirects to the favorites index page with all pets removed, favorites counter to 0, and the text "no favorited pets"

Had to split up the feature tests in order for rspec to pass. Also created model test for helper method. 

Another not-so restful route "favorites#remove_all"